### PR TITLE
Serializer Update

### DIFF
--- a/main/serializers.py
+++ b/main/serializers.py
@@ -34,6 +34,9 @@ class SoloEventSerializer(serializers.ModelSerializer):
 
 class ScheduleSerializer(serializers.ModelSerializer):
     timeframes = serializers.SerializerMethodField()
+    user = serializers.SerializerMethodField()
+    cliques = serializers.SerializerMethodField()
+
     class Meta:
         model = Schedule
         fields = '__all__'
@@ -41,7 +44,15 @@ class ScheduleSerializer(serializers.ModelSerializer):
     def get_timeframes(self, obj):
         data = TimeFrameSerializer(obj.scheduleTimeFrame.all(), many=True).data
         return data
-        
+
+    def get_user(self, obj):
+        data = UserSerializer(obj.user).data
+        return data
+
+    def get_cliques(self, obj):
+        data = CliqueSerializer(obj.cliques.all(), many=True).data
+        return data
+
 class TimeFrameSerializer(serializers.ModelSerializer):
     class Meta:
         model = TimeFrame


### PR DESCRIPTION
I found out that there is a much easier way of adding models related objects to a view: reference the related object in the serializer. I did this with schedules, but there are more objects where this may be beneficial. These are outlined in issue #63. 

We should take some time to decide whether we should add the change in each of those serializers. In some cases, we would be getting more data than needed. In others, it would be very helpful to not make additional API requests to get to the nested related objects that only are referenced by id.